### PR TITLE
Fix swapped words in suggestion

### DIFF
--- a/chex_latex.pl
+++ b/chex_latex.pl
@@ -682,12 +682,12 @@ sub READCODEFILE
 			}
 
 			# This doesn't actually work, though I wish it would - I want to detect a "true" right-leaning apostrophe
-			#if( !$ok && $theline =~ /\’/ ) {
-			#	print "SERIOUS: the special right-leaning apostrophe '’' should be a normal apostrophe on line $. in $input.\n";
+			#if( !$ok && $theline =~ /\Â’/ ) {
+			#	print "SERIOUS: the special right-leaning apostrophe 'Â’' should be a normal apostrophe on line $. in $input.\n";
 			#}
 			# https://www.grammarly.com/blog/modeling-or-modelling/
 			if( !$ok && $lctheline =~ /modelling/ && !$isref ) {
-				print "In the U.S., we prefer 'modelling' to 'modeling' on line $. in $input.\n";
+				print "In the U.S., we prefer 'modeling' to 'modelling' on line $. in $input.\n";
 			}
 			if( !$ok && !$isref && $lctheline =~ /towards/ ) {
 				print "In the U.S., 'towards' should change to 'toward' on line $. in $input.\n";
@@ -796,8 +796,8 @@ sub READCODEFILE
 		#}
 
 		# Latex-specific
-		if( !$ok && !$textonly && $theline =~ /’/ ) {
-			print "SERIOUS: the punctuation ’ should change to a ' (vertical) apostrophe on line $. in $input.\n";
+		if( !$ok && !$textonly && $theline =~ /Â’/ ) {
+			print "SERIOUS: the punctuation Â’ should change to a ' (vertical) apostrophe on line $. in $input.\n";
 		}
 		if( !$ok && !$textonly && !$inequation && $theline =~ /"/ && !($theline =~ /\\"/) ) {
 			print "SERIOUS: the double apostrophe \" should change to a \'\' on line $. in $input.\n";


### PR DESCRIPTION
Fix swapped word order: it is 'modeling' that is preferred in the US (not 'modelling')